### PR TITLE
Add the prometheus-k8s role and rolebinding to enable cluster monitoring

### DIFF
--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - monitor.yaml
+- role.yaml
+- rolebinding.yaml

--- a/config/prometheus/role.yaml
+++ b/config/prometheus/role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s-habana
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - services
+      - nodes
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/prometheus/rolebinding.yaml
+++ b/config/prometheus/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s-habana
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-k8s-habana
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring


### PR DESCRIPTION
This PR adds the required manifests to give permissions to the openshift-monitoring Prometheus operator and instance to be able to fetch the respective Prometheus CRs and scrape the Habana AI targets respectively.

- https://docs.openshift.com/container-platform/4.11/operators/operator_sdk/osdk-monitoring-prometheus.html#osdk-monitoring-custom-metrics_osdk-monitoring-prometheus

To enable cluster monitoring for this namespace, manually label the latter with

```shell
oc label namespace <operator_namespace> openshift.io/cluster-monitoring="true"
```

Signed-off-by: Michail Resvanis <mresvani@redhat.com>