### PR TITLE
Enable CI tests on main and release branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,8 @@ on:
       - 'main'
   push:
     branches:
-      - '*'
-      - '!main'
+      - 'main'
+      - 'release-*'
 
 jobs:
   test:


### PR DESCRIPTION
This PR enables CI tests on the `main` and `release-*` branches, which will also allow codecov to be up to date on the latter.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>