### PR TITLE
Remove unneeded CI test steps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,12 +20,6 @@ jobs:
       with:
         go-version: 1.17
 
-    - name: Create kind cluster
-      uses: helm/kind-action@v1.3.0
-
-    - name: Install mockgen
-      run: go install github.com/golang/mock/mockgen@v1.6.0
-
     - name: Run tests
       run: make test
 


### PR DESCRIPTION
This PR removes 2 unnecessary steps from the test CI pipeline:

- kind
- mockgen, it will be installed if necessary via the respective Makefile rule

Signed-off-by: Michail Resvanis <mresvani@redhat.com>