### PR TITLE
Fix kube-rbac-proxy probe TLS errors

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -28,13 +28,23 @@ spec:
             cpu: 5m
             memory: 64Mi
         livenessProbe:
-          tcpSocket:
-            port: 8443
+          exec:
+            command:
+              - "curl"
+              - "--insecure"
+              - "--head"
+              - "--get"
+              - "https://127.0.0.1:8443/"
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
-          tcpSocket:
-            port: 8443
+          exec:
+            command:
+              - "curl"
+              - "--insecure"
+              - "--head"
+              - "--get"
+              - "https://127.0.0.1:8443/"
           initialDelaySeconds: 5
           periodSeconds: 10
         securityContext:


### PR DESCRIPTION
This PR fixes `kube-rbac-proxy` TLS errors caused by its `{liveness,readiness}Probe`s. Although the TCP `{liveness,readiness}Probe`s of the kube-rbac-proxy container work as expected, i.e. succeed because a connection can be established, kube-rbac-proxy logs an error because of the TLS failures.

Example kube-rbac-proxy TLS error logs:
```shell
I1012 11:01:14.523592 1 main.go:181] Valid token audiences:
I1012 11:01:14.523678 1 main.go:289] Generating self signed cert as no cert is provided
I1012 11:01:15.892945 1 main.go:339] Starting TCP socket on 0.0.0.0:8443
I1012 11:01:15.893243 1 main.go:346] Listening securely on 0.0.0.0:8443
2022/10/12 11:01:22 http: TLS handshake error from 10.131.0.2:45906: EOF
2022/10/12 11:01:32 http: TLS handshake error from 10.131.0.2:53314: EOF
2022/10/12 11:01:32 http: TLS handshake error from 10.131.0.2:53318: EOF
```

We can skip logging all these errors by replacing the TCP probes with ExecActions ones, which use `curl` to try to fetch the headers. This way we verify that the kube-rbac-proxy is up and at the same time we ignore any HTTP 401 errors, to skip making an authenticated request.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>