### PR TITLE
Adjust KMM Module firmware path

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -153,7 +153,7 @@ func (r *moduleReconciler) makeModuleLoader(cr *hlaiv1alpha1.DeviceConfig) kmmv1
 			KernelMappings:  r.makeKernelMappings(cr),
 			Modprobe: kmmv1beta1.ModprobeSpec{
 				ModuleName:   "habanalabs",
-				FirmwarePath: "/opt/lib/firmware/habanalabs",
+				FirmwarePath: "/opt/lib/firmware",
 			},
 		},
 		ServiceAccountName: driverServiceAccount,

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -209,11 +209,7 @@ var _ = Describe("ModuleReconciler", func() {
 
 					Expect(m.Spec.ModuleLoader.Container.Modprobe).ToNot(BeNil())
 					Expect(m.Spec.ModuleLoader.Container.Modprobe.ModuleName).To(Equal("habanalabs"))
-					Expect(m.Spec.ModuleLoader.Container.Modprobe.FirmwarePath).To(Equal("/opt/lib/firmware/habanalabs"))
-					//					modprobeParameters := []string{
-					//						"fw_path_para=/var/lib/firmware",
-					//					}
-					//					Expect(m.Spec.ModuleLoader.Container.Modprobe.Parameters).To(Equal(modprobeParameters))
+					Expect(m.Spec.ModuleLoader.Container.Modprobe.FirmwarePath).To(Equal("/opt/lib/firmware"))
 
 					Expect(m.Spec.ModuleLoader.ServiceAccountName).To(Equal(driverServiceAccount))
 				})


### PR DESCRIPTION
This change removes the additional directory, i.e. `/habanalabs` from the KMM Module firmware path, because of the respective change on the KMM firmware loading implementation. The latter now skips the last directory of the defined firmware path.

- https://github.com/kubernetes-sigs/kernel-module-management/pull/213