### PR TITLE
Add RBAC manifests in CSV and conver ClusterRoleBindings to RoleBindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,8 @@ endef
 bundle: templates manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 #	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
+	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS) \
+		--extra-service-accounts node-labeler,node-metrics,driver-habana,device-plugin
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/config/rbac/device-plugin_role.yaml
+++ b/config/rbac/device-plugin_role.yaml
@@ -1,8 +1,6 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: device-plugin
 rules:
 - apiGroups:

--- a/config/rbac/device-plugin_role_binding.yaml
+++ b/config/rbac/device-plugin_role_binding.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: device-plugin
 roleRef:

--- a/config/rbac/device-plugin_service_account.yaml
+++ b/config/rbac/device-plugin_service_account.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/config/rbac/driver-habana_role.yaml
+++ b/config/rbac/driver-habana_role.yaml
@@ -1,8 +1,6 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: driver-habana
 rules:
 - apiGroups:

--- a/config/rbac/driver-habana_role_binding.yaml
+++ b/config/rbac/driver-habana_role_binding.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: driver-habana
 roleRef:

--- a/config/rbac/driver-habana_service_account.yaml
+++ b/config/rbac/driver-habana_service_account.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/config/rbac/node-labeler_role.yaml
+++ b/config/rbac/node-labeler_role.yaml
@@ -1,8 +1,6 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: node-labeler
 rules:
 - apiGroups:

--- a/config/rbac/node-labeler_role_binding.yaml
+++ b/config/rbac/node-labeler_role_binding.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: node-labeler
 roleRef:

--- a/config/rbac/node-labeler_service_account.yaml
+++ b/config/rbac/node-labeler_service_account.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/config/rbac/node-metrics_role.yaml
+++ b/config/rbac/node-metrics_role.yaml
@@ -1,8 +1,6 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: node-metrics
 rules:
 - apiGroups:

--- a/config/rbac/node-metrics_role_binding.yaml
+++ b/config/rbac/node-metrics_role_binding.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: node-metrics
 roleRef:

--- a/config/rbac/node-metrics_service_account.yaml
+++ b/config/rbac/node-metrics_service_account.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
This change includes the following:

- adds RBAC manifests in the OLM CSV when generating the bundle.

    When packaging additional manifests alongside the CSV, OLM will not
    perform any templating on those. Currently, additional RBAC manifests are
    packaged alongside the HabanaAI operator CSV, i.e. for the node-labeler,
    node-metrics, driver and device-plugin workloads. The RoleBindings of
    those ServiceAccounts include the namespace of the ServiceAccount, which
    should be the operator's namespace. The latter can be chosen dynamically
    by the user when installing the operator. But since OLM won't perform any
    templating on those RoleBindings, the namespace under the subjects spec
    of the latter is now hardcoded to `habana-ai-operator`.

    To resolve this issue, we inject the necessary RBAC manifests directly
    in the CSV via the `--extra-service-accounts` argument of the
    operator-sdk command when creating the OLM bundle. This way the RBAC
    manifests are created and templated properly by OLM when parsing and
    applying the resources included in the CSV.

    - https://sdk.operatorframework.io/docs/building-operators/golang/operator-scope/#configuring-watch-namespaces-dynamically
    - https://sdk.operatorframework.io/docs/advanced-topics/multi-sa/#updating-the-makefile-to-use---extra-service-accounts

- converts additional ClusterRoleBindings to RoleBindings

    Since the operator is installed via OLM in its own namespace and the
    additional RBAC manifests needed for the HabanaAI workload are also
    applied in that same namespace, there is no need for ClusterRoleBindings
    for those ServiceAccounts. RoleBindings can be used instead to provide  
    the same permissions, but only in that specific namespace and not
    cluster-wide. 
   
    - https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding
    
        > a RoleBinding can reference a ClusterRole and bind that ClusterRole to the namespace of the RoleBinding

Signed-off-by: Michail Resvanis <mresvani@redhat.com>