### PR TITLE
Update default driver version to 1.8.0-690

### DIFF
--- a/config/hack/CONTAINER_IMAGES
+++ b/config/hack/CONTAINER_IMAGES
@@ -4,14 +4,14 @@
     "registry": "vault.habana.ai",
     "namespace": "docker-k8s-device-plugin",
     "name": "docker-k8s-device-plugin",
-    "tag": "1.6.0"
+    "tag": "1.8.0"
   },
   {
     "tplvar": "NODE_METRICS_IMAGE",
     "registry": "vault.habana.ai",
     "namespace": "gaudi-metric-exporter",
     "name": "metric-exporter",
-    "tag": "1.6.0-439"
+    "tag": "1.8.0-690"
   },
   {
     "tplvar": "NODE_LABELER_IMAGE",

--- a/config/manager/patches/env_images.yaml
+++ b/config/manager/patches/env_images.yaml
@@ -10,8 +10,8 @@ spec:
         - name: manager
           env:
             - name: "DEVICE_PLUGIN_IMAGE"
-              value: vault.habana.ai/docker-k8s-device-plugin/docker-k8s-device-plugin@sha256:dd58ff65a6afe6732253f325402abb2cb7065393720c9894581c384f07a42783
+              value: vault.habana.ai/docker-k8s-device-plugin/docker-k8s-device-plugin@sha256:c42fe7fe570f20f56a2d45f77d2861f56ba10d44de29cf68b1b8d439d1975586
             - name: "NODE_METRICS_IMAGE"
-              value: vault.habana.ai/gaudi-metric-exporter/metric-exporter@sha256:554d946a72161cb097de9134a5bc61a843b2e301c924b8578de06876cb8cbd68
+              value: vault.habana.ai/gaudi-metric-exporter/metric-exporter@sha256:86e431314b12aa4fafddf4f98e1c4ef4551462fa5b3e61e071ae26767ac9b254
             - name: "NODE_LABELER_IMAGE"
               value: ghcr.io/mwalter-habana/habana-node-labeler@sha256:aded2a3e96799653c73014e0cc6f9badc1a1aea3a5e4ababc34632b4ea52c5e8

--- a/config/manifests/patches/related_images.yaml
+++ b/config/manifests/patches/related_images.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   relatedImages:
     - name: device-plugin
-      image: vault.habana.ai/docker-k8s-device-plugin/docker-k8s-device-plugin@sha256:dd58ff65a6afe6732253f325402abb2cb7065393720c9894581c384f07a42783
+      image: vault.habana.ai/docker-k8s-device-plugin/docker-k8s-device-plugin@sha256:c42fe7fe570f20f56a2d45f77d2861f56ba10d44de29cf68b1b8d439d1975586
     - name: node-metrics
-      image: vault.habana.ai/gaudi-metric-exporter/metric-exporter@sha256:554d946a72161cb097de9134a5bc61a843b2e301c924b8578de06876cb8cbd68
+      image: vault.habana.ai/gaudi-metric-exporter/metric-exporter@sha256:86e431314b12aa4fafddf4f98e1c4ef4551462fa5b3e61e071ae26767ac9b254
     - name: node-labeler
       image: ghcr.io/mwalter-habana/habana-node-labeler@sha256:aded2a3e96799653c73014e0cc6f9badc1a1aea3a5e4ababc34632b4ea52c5e8

--- a/hack/openshift/deviceconfig.yaml
+++ b/hack/openshift/deviceconfig.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: habana-ai-operator
 spec:
   driverImage: ghcr.io/fabiendupont/habana-ai-driver
-  driverVersion: 1.6.0-439
+  driverVersion: 1.8.0-690

--- a/hack/openshift/sample-workload.yaml
+++ b/hack/openshift/sample-workload.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   restartPolicy: OnFailure
   containers:
-  - image: vault.habana.ai/gaudi-docker/1.6.1/ubuntu20.04/habanalabs/tensorflow-installer-tf-cpu-2.9.1:latest
+  - image: vault.habana.ai/gaudi-docker/1.8.0/rhel8.6/habanalabs/tensorflow-installer-tf-cpu-2.11.0:1.8.0-690
     imagePullPolicy: IfNotPresent
     name: habana-ai-base-container
     command:


### PR DESCRIPTION
This change updates the default container images to the Habana driver version 1.8.0-690.